### PR TITLE
use key for refetch

### DIFF
--- a/libs/app/src/lib/region/MapContainer/MapContainer.tsx
+++ b/libs/app/src/lib/region/MapContainer/MapContainer.tsx
@@ -111,6 +111,7 @@ export const MapContainer = () => {
           onClose={() => {
             setIsActive(false)
           }}
+          incKey={() => setKey((prev) => prev + 1)} // cheap reset
         />
       </div>
     </div>

--- a/libs/app/src/lib/region/ScoreModal/PostItem/Menu.tsx
+++ b/libs/app/src/lib/region/ScoreModal/PostItem/Menu.tsx
@@ -3,13 +3,14 @@ import { Post } from '@world-traffic-light/utils'
 interface Props {
   post: Post
   onEditClick: () => void
+  onReset: () => void
 }
 
 export const Menu = (props: Props) => {
   // --------------------- ===
   //  PROPS
   // ---------------------
-  const { post, onEditClick } = props
+  const { post, onEditClick, onReset } = props
 
   // --------------------- ===
   //  RENDER
@@ -23,6 +24,7 @@ export const Menu = (props: Props) => {
       label: 'Delete',
       onClick: async () => {
         await fetch(`/api/posts/${post.id}`, { method: 'DELETE' })
+        onReset()
       },
     },
   ]

--- a/libs/app/src/lib/region/ScoreModal/PostItem/PostItem.tsx
+++ b/libs/app/src/lib/region/ScoreModal/PostItem/PostItem.tsx
@@ -10,13 +10,15 @@ interface Props {
   isEditing: boolean
   onMoreClick: () => void
   onEditClick: () => void
+  onReset: () => void
 }
 
 export const PostItem = (prop: Props) => {
   // --------------------- ===
   //  PROPS
   // ---------------------
-  const { post, isMenuActive, isEditing, onMoreClick, onEditClick } = prop
+  const { post, isMenuActive, isEditing, onMoreClick, onEditClick, onReset } =
+    prop
   const { score, comment, user } = post
 
   const currentUser = getCookie('username')
@@ -74,7 +76,9 @@ export const PostItem = (prop: Props) => {
           <MoreBtn onClick={onMoreClick} isActive={isMenuActive} />
         )}
       </div>
-      {isMenuActive && <Menu post={post} onEditClick={onEditClick} />}
+      {isMenuActive && (
+        <Menu post={post} onEditClick={onEditClick} onReset={onReset} />
+      )}
     </div>
   )
 }

--- a/libs/app/src/lib/region/ScoreModal/ScoreModal.tsx
+++ b/libs/app/src/lib/region/ScoreModal/ScoreModal.tsx
@@ -15,13 +15,14 @@ interface Props {
   selectedProduct: Product
   isActive: boolean
   onClose: () => void
+  incKey: () => void
 }
 
 export const ScoreModal = (props: Props) => {
   // --------------------- ===
   //  PROPS
   // ---------------------
-  const { selectedCountry, selectedProduct, isActive, onClose } = props
+  const { incKey, selectedCountry, selectedProduct, isActive, onClose } = props
 
   // --------------------- ===
   //  STATE
@@ -70,6 +71,7 @@ export const ScoreModal = (props: Props) => {
   const handleFormReset = () => {
     setEditPost(null)
     setIsAddingPost(false)
+    incKey()
   }
 
   // --------------------- ===
@@ -136,6 +138,7 @@ export const ScoreModal = (props: Props) => {
             onEditClick={() => {
               setEditPost(post)
             }}
+            onReset={handleFormReset}
           />
         ))}
       </div>

--- a/libs/utils/src/lib/fetchUtils.ts
+++ b/libs/utils/src/lib/fetchUtils.ts
@@ -67,16 +67,14 @@ const generateRequest = (
       newUrl.searchParams.append(key, body[key])
     })
     if (init.next) {
-      console.log('next tags :>> ', Object.values(body))
       // FIX: TAGS NOT WORKING
       init.next.tags = Object.values(body)
     }
   } else if (body) {
     init.method = options.method || 'POST'
     Object.values(body).forEach((val) => {
-      console.log('revalidateaTag :>> ', val)
       // FIX: TAGS NOT WORKING
-      revalidateTag(val)
+      // revalidateTag(val)
     })
     init.body = JSON.stringify(body)
   }

--- a/next.config.js
+++ b/next.config.js
@@ -12,11 +12,11 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: true,
   },
-  logging: {
-    fetches: {
-      fullUrl: true,
-    },
-  },
+  // logging: {
+  //   fetches: {
+  //     fullUrl: true,
+  //   },
+  // },
 }
 
 const plugins = [

--- a/src/app/mapbox.css
+++ b/src/app/mapbox.css
@@ -3,6 +3,7 @@
 .mapboxgl-popup-content {
   @apply bg-slate-50;
   padding: 1.5rem 2rem;
+  min-width: 12rem;
 }
 
 .mapboxgl-popup-close-button {


### PR DESCRIPTION
I expected the next.js cache to work similarly to React/RTK Query, but `revalidateTags()` and the cache in general aren't working well for me. I likely need to dig a little deeper, but here's a cheap and easy fix to refetch scores and posts when we update data on the api.